### PR TITLE
Ci

### DIFF
--- a/.github/workflows/build_project.yml
+++ b/.github/workflows/build_project.yml
@@ -1,0 +1,35 @@
+name: Project build continuous integration
+
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew build
+        
+      - name: Upload client
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: guardians-division-client
+          path: client/build/libs
+
+      - name: Upload server
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: guardians-division-server
+          path: server/build/libs   
+
+      - name: Upload server manager
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: guardians-division-servermanager
+          path: server_manager/build/libs          

--- a/.github/workflows/build_project.yml
+++ b/.github/workflows/build_project.yml
@@ -1,4 +1,4 @@
-name: Project build continuous integration
+name: Project build and upload
 
 on: [push]
 jobs:
@@ -14,8 +14,9 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
+        # To be added later: custom build for each module (with fatJars)
         run: ./gradlew build
-        
+      
       - name: Upload client
         uses: actions/upload-artifact@v1.0.0
         with:


### PR DESCRIPTION
Adds continuous integration to the project.

Since the previous PR has not been merged yet, the artifacts uploaded are generated with `gradle build`, and not with the custom `fatJar` task that will be present in the submodules after the merge.